### PR TITLE
Fix indexing for filtered progress table

### DIFF
--- a/packages/web/src/routes/progress/+page.svelte
+++ b/packages/web/src/routes/progress/+page.svelte
@@ -59,12 +59,12 @@
 						</tr>
 					</thead>
 					<tbody>
-						{#each filteredTasks as task, index}
-							<tr class="{index % 2 === 0 ? 'bg-black' : 'bg-gray-950'} hover:bg-gray-800">
-								<td class="px-6 py-2 border-b">
-									<a href={`/progress/${task.id}`} class="text-blue-500 hover:underline">
-										{index + 1}. {task.name}
-									</a>
+                                                {#each filteredTasks as task, index}
+                                                        <tr class="{index % 2 === 0 ? 'bg-black' : 'bg-gray-950'} hover:bg-gray-800">
+                                                                <td class="px-6 py-2 border-b">
+                                                                        <a href={`/progress/${task.id}`} class="text-blue-500 hover:underline">
+                                                                                {data.tasks.indexOf(task) + 1}. {task.name}
+                                                                        </a>
 								</td>
 								<td class="px-6 py-2 border-b">
 									<a href={`/progress/${task.id}`} class="flex gap-2 flex-wrap">


### PR DESCRIPTION
## Summary
- show original task index in `/progress` table regardless of filtering

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*

------
https://chatgpt.com/codex/tasks/task_e_68652198b7188323974210dd6bd172a6